### PR TITLE
fix server-side caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Logging is configured with a json. Logging is configured that if the connection 
 
 # Development
 
-## develop sophie modules
-
 Sophie modules follow this versioning scheme: `public-bc.internal-bc.feature` for example `1.2.0` where
 
 - `public-bc`: bumped if there is a bc breaking change in the public styles (css or json) of the package (e.g. things removed, drastic changes)
@@ -33,7 +31,7 @@ This enables usage like this:
 
 Try to not bump `public-bc` for as long as possible (this should be years) as everything using this version should eventually be updated or the version should be maintained and adapted to context redesigns (e.g. nzz.ch gets a redesign) to make old stuff match the new style.
 
-### sophie bundle config
+## sophie bundle config
 
 Add a property `sophie` to your package.json that looks like this to depend on other packages. You can then import things from these packages.
 See tests for examples.
@@ -46,3 +44,113 @@ See tests for examples.
   }
 }
 ```
+
+# Routes
+
+This service has the following routes:
+- GET /bundle/`{bundleId}`.css
+- GET /bundle/`{bundleId}`.vars.json
+
+`{bundleId}`: Comma separated string of Sophie modules.
+
+## Example CSS
+
+```
+GET /bundle/sophie-color@1,sophie-viz-color@1[gender].css
+```
+
+This returns all the [CSS from the module *sophie-color*](https://github.com/nzzdev/sophie-color/tree/master/scss), but only the [CSS from the submodule *gender* from the module *sophie-viz-color*](https://github.com/nzzdev/sophie-viz-color/blob/master/scss/gender.scss). The `@1` sets the version of the Sophie module, from which we want to get the CSS from (in this case we want the newest changes from major version 1).
+
+The response for this example would be:
+
+```css
+.s-color-gray-1 {
+  color: #f0f0f2
+}
+.s-color-gray-2 {
+  color: #e3e4e9
+}
+.s-color-gray-3 {
+  color: #d4d6dd
+}
+...
+.s-viz-color-male-light {
+  color: #7dd1c3
+}
+.s-viz-color-female {
+  color: #6c43c0
+}
+.s-viz-color-female-light {
+  color: #aa90de
+}
+```
+
+## Example JSON
+
+```
+GET /bundle/sophie-color@1.vars.json
+```
+
+This returns all the [CSS variables from the module *sophie-color*](https://github.com/nzzdev/sophie-color/tree/master/vars) as an object.
+
+The response for this example would be:
+
+```json
+{
+  "sophie-color":
+  {
+    "general":
+    {
+      "s-color-gray-1": "#f0f0f2",
+      "s-color-gray-2": "#e3e4e9",
+      ...
+      "s-color-positive": "#46d38e",
+      "s-color-negative": "#e74e4b"
+    }
+  }
+}
+```
+
+# Bundling
+
+## Example CSS
+
+```
+GET /bundle/sophie-color@1,sophie-viz-color@1[gender].css
+```
+First, we split the `bundleId` string into an array of packages:
+
+```javascript
+[
+  { name: 'sophie-color', version: '1', submodules: undefined },
+  { name: 'sophie-viz-color', version: '1', submodules: [ 'gender' ] }
+]
+```
+
+Then, we download the module `sophie-color` in version `1.x.x` from GitHub (if the module is not already server-side cached). Same happens to `sophie-viz-color`.
+
+After downloading, all the SCSS is compiled to CSS.
+
+At last, we return all the CSS from `sophie-color`, but only the CSS from submodule `gender` from `sophie-viz-color`, as a string.
+
+## Example JSON
+
+```
+GET /bundle/sophie-color@1.vars.json
+```
+
+Same process as above, however there is no SCSS-to-CSS compiling happening and also the return value is a JSON object.
+
+# Caching
+
+All downloaded Sophie modules are server-side cached for 7 days.
+
+The following key is used for storing each module:
+
+```javascript
+package.name + "@" + (package.version || package.branch) + ".css"
+```
+
+The response from each route is server-side cached for 7 days as well, using the `bundleId` string as key.
+
+This guarantees, that we don't unnecessarily download repositories from GitHub.

--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ async function start() {
   });
 
   const tmpDir = path.join(__dirname, "/tmp");
-  console.log("$----", fs.readdirSync(tmpDir));
   await fs.emptyDir(tmpDir);
 
   await server.register({

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const fs = require("fs-extra");
 const Hapi = require("@hapi/hapi");
 const routes = require("./routes/routes.js");
 const path = require("path");
@@ -51,17 +52,20 @@ async function start() {
     plugin: require("./plugins/sophie-bundle/index.js"),
   });
 
+  const tmpDir = path.join(__dirname, "/tmp");
+  await fs.emptyDir(tmpDir);
+
   await server.register({
     plugin: require("./plugins/sophie-bundle-css/index.js"),
     options: {
-      tmpDir: path.join(__dirname, "/tmp"),
+      tmpDir: tmpDir,
     },
   });
 
   await server.register({
     plugin: require("./plugins/sophie-bundle-vars-json/index.js"),
     options: {
-      tmpDir: path.join(__dirname, "/tmp"),
+      tmpDir: tmpDir,
     },
   });
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ async function start() {
   });
 
   const tmpDir = path.join(__dirname, "/tmp");
+  console.log("$----", fs.readdirSync(tmpDir));
   await fs.emptyDir(tmpDir);
 
   await server.register({

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "sophie-build-service",
       "version": "2.4.4",
       "license": "MIT",
       "dependencies": {
@@ -1223,14 +1222,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+      "version": "1.0.30001339",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -4222,9 +4227,9 @@
       "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+      "version": "1.0.30001339",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ==",
       "dev": true
     },
     "chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sophie-build-service",
       "version": "2.4.4",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sophie Build Service",
   "main": "index.js",
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -c -P tests --verbose --leaks"
+    "test": "lab -a @hapi/code -t 80 -c -P tests --verbose --leaks"
   },
   "author": "Beni Buess <beni.buess@nzz.ch>",
   "license": "MIT",

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -82,7 +82,7 @@ module.exports = {
       },
       {
         cache: defaultServerMethodCaching,
-        generateKey: (package) => package.name + "@" + package.version + ".css",
+        generateKey: (package) => package.name + "@" + (package.version || package.branch) + ".css",
       }
     )
 

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -100,11 +100,13 @@ module.exports = {
           if (package.submodules) {
             compiledStyles += compiledPackageStyles
               .filter((submodule) => package.submodules.map((submoduleName) => `scss/${submoduleName}.scss`).includes(submodule.file))
-              .map((submodule) => submodule.style);
+              .map((submodule) => submodule.style)
+              .join("");
           } else {
             // if no submodules are given, we compile all submodules
             compiledStyles += compiledPackageStyles
-              .map((submodule) => submodule.style);
+              .map((submodule) => submodule.style)
+              .join("");
           }
         }
         return compiledStyles;

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -109,9 +109,9 @@ module.exports = {
         }
         return compiledStyles;
       },
-      // {
-      //   cache: defaultServerMethodCaching,
-      // }
+      {
+        cache: defaultServerMethodCaching,
+      }
     );
   },
 };

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -26,7 +26,6 @@ function compileStyle(loadPath, filesToCompile) {
         outputStyle: "compressed",
       });
     } catch (error) {
-      // server.log(["debug"], error);
       throw new Error(
         `sass compilation error in file ${file}: ${error.message}`
       );
@@ -73,7 +72,6 @@ module.exports = {
           // compile all sass from this package and its submodules
           return compileStyle(loadPath, filesToCompile);
         } catch (error) {
-          // server.log(["debug"], error);
           throw error;
         }
       },

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -11,114 +11,107 @@ const defaultServerMethodCaching = {
   generateTimeout: 60 * 1000, // 1 minute
 };
 
+function compileStyle(package, loadPath, filesToCompile) {
+  let compiledStyles = "", fileName;
+
+  while ((fileName = filesToCompile.shift())) {
+    // server.log(["debug"], `compiling styles ${fileName} of ${package.name}`);
+    let rendered;
+
+    try {
+      rendered = sass.renderSync({
+        file: path.join(loadPath, fileName),
+        includePaths: [
+          path.join(loadPath, "sophie_packages"),
+        ],
+        importer: [jsonImporter()],
+        outputStyle: "compressed",
+      });
+    } catch (err) {
+      throw Boom.badImplementation(
+        `sass compilation error in package
+        ${package.name} file ${fileName}: ${err.message}`
+      );
+    }
+
+    compiledStyles += rendered.css.toString();
+    // server.log(["debug"], `compiled styles ${fileName} of ${package.name}`);
+  }
+  return compiledStyles;
+}
+
 module.exports = {
   name: "sophie-bundle-css",
   register: async function (server, options) {
     Hoek.assert(options.tmpDir, "tmpDir is a required option");
 
-    // $lab:coverage:off$
     const cacheConfig = Hoek.applyToDefaults(
       defaultServerMethodCaching,
       options.serverCacheConfig || {}
     );
-    // $lab:coverage:on$
+
+    server.method(
+      "sophie.processPackage",
+      async function (package, pathPrefix) {
+        // download GitHub repository tarball for this package and save it to 'loadPath'
+        const loadPath = path.join(
+          pathPrefix,
+          package.name,
+          package.version || package.branch
+        );
+        await server.methods.sophie.loadPackage(package, loadPath);
+
+        // if this package has submodules, we need to compile them as well
+        let filesToCompile = [];
+        if (!package.submodules) {
+          // if no submodules are given, we compile all submodules
+          // check if there is the scss directory first to not fail if a module has no submodules
+          const submodulePath = path.join(
+            pathPrefix,
+            package.name,
+            package.version || package.branch,
+            "scss"
+          );
+          if (fs.existsSync(submodulePath)) {
+            const submoduleFiles = fs.readdirSync(submodulePath);
+            filesToCompile = submoduleFiles.map((file) => `scss/${file}`);
+          } else {
+            // this is mostly a fallback for older style sophie modules that just have a main.scss file
+            filesToCompile = ["main.scss"];
+          }
+        } else {
+          filesToCompile = package.submodules.map((sm) => `scss/${sm}.scss`);
+        }
+
+        // compile all sass from this package and its submodules
+        return compileStyle(package, loadPath, filesToCompile);
+      },
+      {
+        cache: cacheConfig,
+        generateKey: (package) => package.name + "/" + package.version,
+      }
+    )
 
     server.method(
       "sophie.generateBundle.css",
       async function (bundleId) {
-        const packages =
-          server.methods.sophie.bundle.getPackagesFromBundleId(bundleId);
+        const packages = server.methods.sophie.bundle.getPackagesFromBundleId(bundleId);
         const packagesHash = crypto
           .createHash("md5")
           .update(bundleId)
           .digest("hex");
         const pathPrefix = path.join(options.tmpDir, packagesHash);
-
-        await server.methods.sophie.loadPackages(packages, pathPrefix);
-        server.log(["debug"], `got all packages ready at ${options.tmpDir}`);
-
         let compiledStyles = "";
-        for (const pack of packages) {
-          const packageInfo = JSON.parse(
-            fs.readFileSync(
-              path.join(
-                pathPrefix,
-                pack.name,
-                pack.version || pack.branch,
-                "package.json"
-              )
-            )
-          );
-          const sophiePackageInfo = packageInfo.sophie || {};
 
-          let filesToCompile = [];
-          if (!pack.submodules) {
-            // if no submodules are given, we compile all submodules
-            // check if there is the scss directory first to not fail if a module has no submodules
-            const submodulePath = path.join(
-              pathPrefix,
-              pack.name,
-              pack.version || pack.branch,
-              "scss"
-            );
-            if (fs.existsSync(submodulePath)) {
-              const submoduleFiles = fs.readdirSync(submodulePath);
-              filesToCompile = submoduleFiles.map((file) => `scss/${file}`);
-            } else {
-              // this is mostly a fallback for older style sophie modules that just have a main.scss file
-              filesToCompile = ["main.scss"];
-            }
-          } else {
-            filesToCompile = pack.submodules.map((sm) => `scss/${sm}.scss`);
-          }
-
-          let fileName;
-          while ((fileName = filesToCompile.shift())) {
-            server.log(
-              ["debug"],
-              `compiling styles ${fileName} of ${pack.name}`
-            );
-            let rendered;
-            try {
-              rendered = sass.renderSync({
-                file: path.join(
-                  pathPrefix,
-                  pack.name,
-                  pack.version || pack.branch,
-                  fileName
-                ),
-                includePaths: [
-                  path.join(
-                    pathPrefix,
-                    pack.name,
-                    pack.version || pack.branch,
-                    "sophie_packages"
-                  ),
-                ],
-                importer: [jsonImporter()],
-                outputStyle: "compressed",
-              });
-            } catch (err) {
-              throw Boom.badImplementation(
-                `sass compilation error in package
-                ${pack.name} file ${fileName}: ${err.message}`
-              );
-            }
-
-            const styles = rendered.css.toString();
-            server.log(
-              ["debug"],
-              `compiled styles ${fileName} of ${pack.name}`
-            );
-            compiledStyles += styles;
-          }
+        for (const package of packages) {
+          compiledStyles += await server.methods.sophie.processPackage(package, pathPrefix);
         }
 
         return compiledStyles;
       },
-      {
-        cache: cacheConfig,
-      }
+      // {
+      //   cache: cacheConfig,
+      // }
     );
   },
 };

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -45,12 +45,7 @@ module.exports = {
   name: "sophie-bundle-css",
   register: async function (server, options) {
     Hoek.assert(options.tmpDir, "tmpDir is a required option");
-
-    const cacheConfig = Hoek.applyToDefaults(
-      defaultServerMethodCaching,
-      options.serverCacheConfig || {}
-    );
-
+    
     server.method(
       "sophie.processPackage",
       async function (package, pathPrefix) {
@@ -94,7 +89,7 @@ module.exports = {
         }
       },
       {
-        cache: cacheConfig,
+        cache: defaultServerMethodCaching,
         generateKey: (package) => package.name + "/" + package.version,
       }
     )
@@ -117,7 +112,7 @@ module.exports = {
         return compiledStyles;
       },
       // {
-      //   cache: cacheConfig,
+      //   cache: defaultServerMethodCaching,
       // }
     );
   },

--- a/plugins/sophie-bundle-css/index.js
+++ b/plugins/sophie-bundle-css/index.js
@@ -8,8 +8,6 @@ const crypto = require("crypto");
 
 const defaultServerMethodCaching = {
   expiresIn: 48 * 60 * 60 * 1000, // expire after 48 hours
-  staleIn: 1 * 60 * 5 * 1000, // rebuild bundles every 5 minutes on request
-  staleTimeout: 1, // do not wait before returning a stale bundle
   generateTimeout: 60 * 1000, // 1 minute
 };
 

--- a/plugins/sophie-bundle-vars-json/index.js
+++ b/plugins/sophie-bundle-vars-json/index.js
@@ -5,8 +5,6 @@ const crypto = require("crypto");
 
 const defaultServerMethodCaching = {
   expiresIn: 48 * 60 * 60 * 1000, // expire after 48 hours
-  staleIn: 1 * 60 * 5 * 1000, // rebuild bundles every 5 minutes on request
-  staleTimeout: 1, // do not wait before returning a stale bundle
   generateTimeout: 60 * 1000 // 1 minute
 };
 

--- a/plugins/sophie-bundle-vars-json/index.js
+++ b/plugins/sophie-bundle-vars-json/index.js
@@ -64,7 +64,7 @@ module.exports = {
       },
       {
         cache: defaultServerMethodCaching,
-        generateKey: (package) => package.name + "@" + package.version + ".vars.json",
+        generateKey: (package) => package.name + "@" + (package.version || package.branch) + ".vars.json",
       }
     )
 

--- a/plugins/sophie-bundle-vars-json/index.js
+++ b/plugins/sophie-bundle-vars-json/index.js
@@ -54,7 +54,6 @@ module.exports = {
           // compile all sass from this package and its submodules
           return compileVars(loadPath, filesToCompile); 
         } catch (error) {
-          // server.log(["debug"], error);
           throw error;
         }
       },

--- a/plugins/sophie-bundle-vars-json/index.js
+++ b/plugins/sophie-bundle-vars-json/index.js
@@ -4,7 +4,7 @@ const Hoek = require("@hapi/hoek");
 const crypto = require("crypto");
 
 const defaultServerMethodCaching = {
-  expiresIn: 48 * 60 * 60 * 1000, // expire after 48 hours
+  expiresIn: 7 * 24 * 60 * 60 * 1000, // expire after 7 days
   generateTimeout: 60 * 1000 // 1 minute
 };
 

--- a/plugins/sophie-bundle-vars-json/index.js
+++ b/plugins/sophie-bundle-vars-json/index.js
@@ -89,9 +89,9 @@ module.exports = {
         }
         return JSON.stringify(compiledVars);
       },
-      // {
-      //   cache: defaultServerMethodCaching
-      // }
+      {
+        cache: defaultServerMethodCaching,
+      }
     );
   }
 };

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -12,7 +12,6 @@ module.exports = [
     options: {
       tmpDir: path.join(__dirname, "/tmp"),
       serverCacheConfig: {
-        staleTimeout: 99
       }
     }
   },

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -11,14 +11,12 @@ module.exports = [
     plugin: require("../plugins/sophie-bundle-css/index.js"),
     options: {
       tmpDir: path.join(__dirname, "/tmp"),
-      serverCacheConfig: {
-      }
     }
   },
   {
     plugin: require("../plugins/sophie-bundle-vars-json/index.js"),
     options: {
-      tmpDir: path.join(__dirname, "/tmp")
+      tmpDir: path.join(__dirname, "/tmp"),
     }
   }
 ];


### PR DESCRIPTION
Improves server-side caching of Sophie modules.
Branch deployed on Staging.
Clear cache by redeploy the service.

## Process before

- GET request: `/bundle/sophie-color@1,sophie-viz-color@1.css`
- Download sophie-color and sophie-viz-color from GitHub
- Transpile sophie-color and sophie-viz-color to css
- Cache response and return all css

## Process now

- GET request: `/bundle/sophie-color@1,sophie-viz-color@1.css`
- sophie-color cached? If not, download from GitHub and cache sophie-color
- Transpile sophie-color to css
- sophie-viz-color cached? If not, download from GitHub and cache sophie-viz-color
- Transpile sophie-viz-color to css
- Cache response and return all css

## Testing

### .css

- https://sophieservicestage-2cac.kxcdn.com/bundle/sophie-color@1.css
- https://sophieservicestage-2cac.kxcdn.com/bundle/sophie-viz-color@1[gender].css
- https://sophieservicestage-2cac.kxcdn.com/bundle/sophie-color@1,sophie-font@1,sophie-q@1,sophie-viz-color@1,sophie-legend@1[icon-label].css

### .vars.json

- https://sophieservicestage-2cac.kxcdn.com/bundle/sophie-color@1.vars.json
- https://sophieservicestage-2cac.kxcdn.com/bundle/sophie-viz-color@1[gender].vars.json
- https://sophieservicestage-2cac.kxcdn.com/bundle/sophie-color@1,sophie-font@1,sophie-q@1,sophie-viz-color@1,sophie-legend@1[icon-label].vars.json